### PR TITLE
Fix transferBatch on token contract

### DIFF
--- a/src/core/classes/drop-erc1155-history.ts
+++ b/src/core/classes/drop-erc1155-history.ts
@@ -1,6 +1,6 @@
 import { DropERC1155 } from "@thirdweb-dev/contracts";
 import { ContractWrapper } from "./contract-wrapper";
-import { BigNumberish } from "ethers";
+import { BigNumber, BigNumberish } from "ethers";
 
 /**
  * Manages history for Edition Drop contracts

--- a/src/core/classes/drop-erc1155-history.ts
+++ b/src/core/classes/drop-erc1155-history.ts
@@ -33,7 +33,10 @@ export class DropErc1155History {
     tokenId: BigNumberish,
   ): Promise<string[]> {
     const a = await this.contractWrapper.readContract.queryFilter(
-      this.contractWrapper.readContract.filters.TokensClaimed(null, tokenId),
+      this.contractWrapper.readContract.filters.TokensClaimed(
+        null,
+        BigNumber.from(tokenId),
+      ),
     );
     return Array.from(new Set(a.map((b) => b.args.claimer)));
   }

--- a/src/core/classes/erc-20.ts
+++ b/src/core/classes/erc-20.ts
@@ -310,12 +310,17 @@ export class Erc20<T extends TokenERC20> implements UpdateableNetwork {
    * ```
    */
   public async transferBatch(args: TokenMintInput[]) {
-    const encoded = args.map((arg) =>
-      this.contractWrapper.readContract.interface.encodeFunctionData(
+    const decimals = await this.contractWrapper.readContract.decimals();
+    const encoded = args.map((arg) => {
+      const amountWithDecimals = ethers.utils.parseUnits(
+        BigNumber.from(arg.amount).toString(),
+        decimals,
+      );
+      return this.contractWrapper.readContract.interface.encodeFunctionData(
         "transfer",
-        [arg.toAddress, arg.amount],
-      ),
-    );
+        [arg.toAddress, amountWithDecimals],
+      );
+    });
     await this.contractWrapper.multiCall(encoded);
   }
 

--- a/test/token.test.ts
+++ b/test/token.test.ts
@@ -117,7 +117,7 @@ describe("Token Contract", async () => {
     await currencyContract.transferBatch(batch);
 
     for (const b of batch) {
-      const expectedBalance = BigNumber.from(10);
+      const expectedBalance = ethers.utils.parseEther("10");
       const actualBalance = (await currencyContract.balanceOf(b.toAddress))
         .value;
 


### PR DESCRIPTION
Also Convert to BigNumber to be able to pass tokenId as string on getAllClaimerAddresses