### PR TITLE
Don't force gas estimates on the front end

### DIFF
--- a/src/core/classes/contract-wrapper.ts
+++ b/src/core/classes/contract-wrapper.ts
@@ -107,6 +107,13 @@ export class ContractWrapper<
    * @internal
    */
   public async getCallOverrides(): Promise<CallOverrides> {
+    const isBrowser = () => typeof window !== "undefined";
+    if (isBrowser()) {
+      // When running in the browser, let the wallet suggest gas estimates
+      // this means that the gas speed preferences set in the SDK options are ignored in a browser context
+      // but it also allows users to select their own gas speed prefs per tx from their wallet directly
+      return {};
+    }
     const feeData = await this.getProvider().getFeeData();
     const supports1559 = feeData.maxFeePerGas && feeData.maxPriorityFeePerGas;
     if (supports1559) {


### PR DESCRIPTION
Disable our home made gas estimates based on SDK options speed on the frontend.

The reason is that on the browser, most wallets will have their own UI/handling of gas estimates (ie. metamask shows their own 3 options for slow/medium/fast) which allows front end users to choose their gas spending (rather than it being imposed by whatever the SDK is configured with).

This also fixes an ongoing issue where users just want to "see" how much something is going to cost without having the funds themselves. By letting the wallet do the gas estimations, it will always popup and let the user know the price, as well as if they have enough funds in their wallet or not.