### PR TITLE
Allow for explicit entry of bytes as bytes32 param when publishing

### DIFF
--- a/src/core/classes/contract-publisher.ts
+++ b/src/core/classes/contract-publisher.ts
@@ -284,7 +284,7 @@ export class ContractPublisher extends RPCConnectionHandler {
         }
       }
       if (p === "bytes32") {
-        if (!isNaN(constructorParamValues[index])) {
+        if (!isNaN(constructorParamValues[index]) && constructorParamValues[index] > 0) {
           return ethers.utils.hexZeroPad(
             ethers.utils.hexlify(
               ethers.BigNumber.from(constructorParamValues[index]),

--- a/src/core/classes/contract-publisher.ts
+++ b/src/core/classes/contract-publisher.ts
@@ -284,7 +284,7 @@ export class ContractPublisher extends RPCConnectionHandler {
         }
       }
       if (p === "bytes32") {
-        if (!isNaN(constructorParamValues[index]) && constructorParamValues[index] > 0) {
+        if (!isNaN(constructorParamValues[index]) && constructorParamValues[index] >= 0) {
           return ethers.utils.hexZeroPad(
             ethers.utils.hexlify(
               ethers.BigNumber.from(constructorParamValues[index]),

--- a/src/core/classes/contract-publisher.ts
+++ b/src/core/classes/contract-publisher.ts
@@ -284,12 +284,18 @@ export class ContractPublisher extends RPCConnectionHandler {
         }
       }
       if (p === "bytes32") {
-        return ethers.utils.hexZeroPad(
-          ethers.utils.hexlify(
+        if (!isNaN(constructorParamValues[index])) {
+          return ethers.utils.hexZeroPad(
+            ethers.utils.hexlify(
+              ethers.BigNumber.from(constructorParamValues[index]),
+            ),
+            32,
+          );
+        } else {
+          return ethers.utils.formatBytes32String(
             constructorParamValues[index].toString(),
-          ),
-          32,
-        );
+          );
+        }
       }
       if (p.startsWith("bytes")) {
         return ethers.utils.toUtf8Bytes(

--- a/src/core/classes/contract-publisher.ts
+++ b/src/core/classes/contract-publisher.ts
@@ -284,8 +284,11 @@ export class ContractPublisher extends RPCConnectionHandler {
         }
       }
       if (p === "bytes32") {
-        return ethers.utils.formatBytes32String(
-          constructorParamValues[index].toString(),
+        return ethers.utils.hexZeroPad(
+          ethers.utils.hexlify(
+            constructorParamValues[index].toString(),
+          ),
+          32,
         );
       }
       if (p.startsWith("bytes")) {


### PR DESCRIPTION
Previously the deployment form would throw "bytes32 string must be less than 32 bytes" (see screenshot) when entering 32bytes directly as a byte string. This is because `formatBytes32String` was being used which is for converting strings to bytes. Instead, should be using `hexlify` and `hexZeroPad` functions

<img width="1013" alt="Screen Shot 2022-05-31 at 9 50 10 AM" src="https://user-images.githubusercontent.com/87501783/171272089-cda97c5b-5c30-479b-a352-bd50cc0b05ab.png">
 