### PR TITLE
Bugfix - Incorrect entrypoint being loaded when using Node ESModules

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "unpkg": "dist/browser/index.global.js",
   "exports": {
     "node": {
-      "module": "./dist/node/index.mjs",
+      "import": "./dist/node/index.mjs",
       "require": "./dist/node/index.js"
     },
     "default": "./dist/browser/index.mjs"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "exports": {
     "node": {
       "import": "./dist/node/index.mjs",
+      "module": "./dist/node/index.mjs",
       "require": "./dist/node/index.js"
     },
     "default": "./dist/browser/index.mjs"


### PR DESCRIPTION
When attempting to load the SDK from a Node script the Browser package is being loaded. This is because `module` does not appear to be a [known condition](https://nodejs.org/api/packages.html#conditional-exports) and therefore it skips and loads the `default` entrypoint (`browser`).