### PR TITLE
Update code snippet example for Edition Drop Contract

### DIFF
--- a/src/core/classes/erc-1155.ts
+++ b/src/core/classes/erc-1155.ts
@@ -222,6 +222,8 @@ export class Erc1155<
    *
    * @example
    * ```javascript
+   * // The token ID of the NFT you want to airdrop
+   * const tokenId = "0";
    * // Array of objects of addresses and quantities to airdrop NFTs to
    * const addresses = [
    *  {
@@ -233,15 +235,15 @@ export class Erc1155<
    *    quantity: 3,
    *  },
    * ];
-   * const tokenId = "0";
-   * await contract.airdrop(addresses, tokenId);
+   * await contract.airdrop(tokenId, addresses);
    *
    * // You can also pass an array of addresses, it will airdrop 1 NFT per address
+   * const tokenId = "0";
    * const addresses = [
    *  "0x...", "0x...", "0x...",
    * ]
-   * const tokenId = "0";
-   * await contract.airdrop(addresses, tokenId);
+   * 
+   * await contract.airdrop(tokenId, addresses);
    * ```
    */
   public async airdrop(


### PR DESCRIPTION
In the Contract Dashboard the example provided is:
`await contract.airdrop(addresses, tokenId)`

But in the [documentation here](https://portal.thirdweb.com/typescript/sdk.Erc1155.airdrop) the parameter order is specified as
`airdrop(tokenId: BigNumberish, addresses: AirdropInput, data?: BytesLike): Promise<TransactionResult>;`

So you place `tokenId` before `addresses`, otherwise you get an `invalid BigNumber value` error upon executing the function.

This pull request is to update the code snippet to accurately reflect the contract function invocation. 