### PR TITLE
Improve error messages on SDK(Integrating changes from 2.4.2 to SDK)

### DIFF
--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -320,6 +320,7 @@ export async function convertToTWError(
     return error;
   }
   const reason =
+    error.errorMessage ||
     error.reason ||
     parseMessageParts(/.*?"message[^a-zA-Z0-9]*([^"\\]*).*?/, raw);
   const data = parseMessageParts(/.*?"data[^a-zA-Z0-9]*([^"\\]*).*?/, raw);


### PR DESCRIPTION
Going forward, we'll have custom errors  for our contracts. This will allow us to have more meaningful errors for our SDK

let the error be error TheCustomError();

```
     method = “theMethodWhereErrorOccured()”
    data = “…” — it is the 4 bytes of custom error here
    errorArgs = [] (or the arguments passed to the custom error declaration)
    errorName = “TheCustomError”
    errorSignature = “TheCustomError()”
    reason = null
   ```