### PR TITLE
Update contract-publisher.ts

### DIFF
--- a/src/core/classes/contract-publisher.ts
+++ b/src/core/classes/contract-publisher.ts
@@ -325,8 +325,8 @@ export class ContractPublisher extends RPCConnectionHandler {
     const contractId = predeployMetadata.name;
 
     const fullMetadata = FullPublishMetadataSchema.parse({
-      ...predeployMetadata,
       ...extraMetadata,
+      ...predeployMetadata,
       publisher,
     });
     const fullMetadataUri = await this.storage.uploadMetadata(fullMetadata);


### PR DESCRIPTION
Predeploy metadata and extra metadata should be inverted, otherwise the dashboard can override the compiler metadata using the data from the previous release.