### PR TITLE
fix: do not minify compiled sources for Node.js

### DIFF
--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,7 +12,7 @@ export default defineConfig([
     sourcemap: true,
     // we'll just manually "clean" the dist dir before running this (to avoid potential race conditions)
     clean: false,
-    minify: true,
+    minify: false,
     platform: "node",
     replaceNodeEnv: true,
     // now required because not defaulted anymore


### PR DESCRIPTION
Minification makes debugging this project in its installed form practically impossible because

1. you cannot reasonably step through the code
2. variable names are unreadable

I understand the motivation to minify the codebase when targetting web browsers to reduce the overal size of the SDK but for Node.js file size is only a problem when it goes to the extremes.

I would like to also ask you, should you accept this PR, to also publish a non-minified version of the SDK to npm. 🙏