### PR TITLE
fix: restore compatibility with experimental built-in fetch in Node v18

### DIFF
--- a/src/core/classes/ipfs-storage.ts
+++ b/src/core/classes/ipfs-storage.ts
@@ -322,8 +322,9 @@ export class IpfsStorage implements IStorage {
       method: "POST",
       headers: {
         Authorization: `Bearer ${token}`,
+        ...formData.getHeaders(),
       },
-      body: formData as any,
+      body: formData.getBuffer(),
     });
     if (!res.ok) {
       throw new Error(`Failed to upload to IPFS [status code = ${res.status}]`);

--- a/src/core/uploaders/pinata-uploader.ts
+++ b/src/core/uploaders/pinata-uploader.ts
@@ -63,8 +63,9 @@ export class PinataUploader implements IStorageUpload {
         method: "POST",
         headers: {
           Authorization: `Bearer ${token}`,
+          ...data.getHeaders(),
         },
-        body: data as any,
+        body: data.getBuffer(),
       });
       const body = await res.json();
       if (!res.ok) {


### PR DESCRIPTION
As of Node.js v18, Node has a built-in, experimental support for global `fetch`. Unfortunately, this implementation is not compatible with `form-data` npm package and when an instance of this package's `FormData` class is provided as a body the native implementation resorts to serialising the form data by calling `.toString()` on it, causing the request's body to become the string literal `"[object FormData]"`.

We can work around that compatibility issue by explicitly using the form's headers and body as a buffer as the inputs to `fetch`.